### PR TITLE
fix: resolve ESLint errors blocking semantic release

### DIFF
--- a/src/orcaOutputSymbolProvider.ts
+++ b/src/orcaOutputSymbolProvider.ts
@@ -13,7 +13,7 @@ export class OrcaOutputSymbolProvider implements vscode.DocumentSymbolProvider {
      */
     provideDocumentSymbols(
         document: vscode.TextDocument,
-        token: vscode.CancellationToken
+        _token: vscode.CancellationToken
     ): vscode.ProviderResult<vscode.DocumentSymbol[]> {
         const symbols: vscode.DocumentSymbol[] = [];
         const text = document.getText();

--- a/src/orcaRunner.ts
+++ b/src/orcaRunner.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { spawn, ChildProcess } from 'child_process';
 import { OutputFileWriter } from './outputFileWriter';
-import { parseOrcaOutput, OrcaParseResult } from './outputParser';
+import { parseOrcaOutput } from './outputParser';
 import { setRunningFile } from './orcaCodeLensProvider';
 import { readFileWithEncoding, readFileTail } from './utils/fileEncoding';
 
@@ -223,7 +223,7 @@ export class OrcaRunner {
                 try {
                     await this.outputFileWriter.close();
                     this.outputFileWriter = null;
-                } catch (closeErr) {
+                } catch (_closeErr) {
                     // Ignore errors during cleanup
                 }
             }


### PR DESCRIPTION
## Problem
The semantic release workflow is failing due to ESLint errors introduced in the Vue3/PrimeVue migration PR.

## Changes
- Remove unused `vscode` import from outputFileWriter.ts
- Replace non-null assertions with proper null checks
- Replace `any` type with proper type assertion
- Remove unused `OrcaParseResult` import from orcaRunner.ts
- Prefix unused variables with underscore (_closeErr, _token)

## Testing
- ✅ ESLint passes with only warnings in test files (non-blocking)
- ✅ TypeScript compilation succeeds

Fixes #14 (semantic release failure)