### PR TITLE
feat(input): Expand functionals and basis sets for Input Creation

### DIFF
--- a/snippets/orca.json
+++ b/snippets/orca.json
@@ -2,7 +2,7 @@
   "Single Point Energy Calculation": {
     "prefix": "sp",
     "body": [
-      "! ${1|B3LYP,PBE0,wB97X-D3,M06-2X,HF,MP2|} ${2|def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,6-31G*|} ${3|TightSCF,VeryTightSCF|}",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} ${3|TightSCF,VeryTightSCF|}",
       "",
       "* xyz ${4:0} ${5:1}",
       "${6:  C  0.0  0.0  0.0}",
@@ -14,7 +14,7 @@
   "Geometry Optimization": {
     "prefix": "opt",
     "body": [
-      "! ${1|B3LYP,PBE0,wB97X-D3,M06-2X|} ${2|def2-SVP,def2-TZVP,def2-QZVP|} Opt ${3|TightOpt,VeryTightOpt|} ${4|TightSCF,VeryTightSCF|}",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} Opt ${3|TightOpt,VeryTightOpt|} ${4|TightSCF,VeryTightSCF|}",
       "",
       "* xyz ${5:0} ${6:1}",
       "${7:  C  0.0  0.0  0.0}",
@@ -26,7 +26,7 @@
   "Frequency Calculation": {
     "prefix": "freq",
     "body": [
-      "! ${1|B3LYP,PBE0,wB97X-D3,M06-2X|} ${2|def2-SVP,def2-TZVP,def2-QZVP|} Freq ${3|TightSCF,VeryTightSCF|}",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} Freq ${3|TightSCF,VeryTightSCF|}",
       "",
       "* xyz ${4:0} ${5:1}",
       "${6:  C  0.0  0.0  0.0}",
@@ -38,7 +38,7 @@
   "Optimization + Frequency": {
     "prefix": "optfreq",
     "body": [
-      "! ${1|B3LYP,PBE0,wB97X-D3,M06-2X|} ${2|def2-SVP,def2-TZVP|} Opt Freq ${3|TightSCF,VeryTightSCF|}",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} Opt Freq ${3|TightSCF,VeryTightSCF|}",
       "",
       "* xyz ${4:0} ${5:1}",
       "${6:  C  0.0  0.0  0.0}",
@@ -50,7 +50,7 @@
   "Transition State Optimization": {
     "prefix": "ts",
     "body": [
-      "! ${1|B3LYP,PBE0,wB97X-D3|} ${2|def2-SVP,def2-TZVP|} OptTS Freq ${3|TightSCF,VeryTightSCF|}",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} OptTS Freq ${3|TightSCF,VeryTightSCF|}",
       "",
       "%geom",
       "  Calc_Hess true",
@@ -67,7 +67,7 @@
   "Solvent (CPCM)": {
     "prefix": "cpcm",
     "body": [
-      "! ${1|B3LYP,PBE0,wB97X-D3|} ${2|def2-SVP,def2-TZVP|} CPCM",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} CPCM",
       "",
       "%cpcm",
       "  smd true",
@@ -141,7 +141,7 @@
   "NEB Calculation": {
     "prefix": "neb",
     "body": [
-      "! ${1|B3LYP,PBE0|} ${2|def2-SVP,def2-TZVP|} NEB-TS",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} NEB-TS",
       "",
       "%neb",
       "  NImages ${3:8}",
@@ -170,7 +170,7 @@
   "TDDFT Calculation": {
     "prefix": "tddft",
     "body": [
-      "! ${1|B3LYP,CAM-B3LYP,PBE0|} ${2|def2-SVP,def2-TZVP|} ${3|TightSCF,VeryTightSCF|}",
+      "! ${1|B3LYP,B3LYP D3,CAM-B3LYP,wB97X-D,wB97X-D3,wB97M-V,M06,M06-2X,TPSSh,HFS,VWN5,PBE,BLYP,BP86,B97D,M06L,SCANfunc,RSCAN,R2SCAN,PBE0,B97,TPSS0,r2SCAN0,r2SCAN50,wB97,wB97X,HF,MP2,RI-MP2,DLPNO-MP2,CCSD,CCSD(T),CASSCF,NEVPT2|} ${2|6-31G(d),6-31G*,6-311G,6-311+G(d\\,P),def2-SVP,def2-TZVP,def2-QZVP,cc-pVDZ,cc-pVTZ,aug-cc-pVTZ,LANL2DZ,SDD,pc-1,pc-2|} ${3|TightSCF,VeryTightSCF|}",
       "",
       "%tddft",
       "  NRoots ${4:10}",

--- a/src/outputParser.ts
+++ b/src/outputParser.ts
@@ -153,9 +153,10 @@ export function parseOrcaOutputEnhanced(content: string): ParsedResults {
         
         // Common DFT methods and Wavefunction methods
         const methods = [
-            'B3LYP', 'PBE', 'PBE0', 'BP86', 'TPSS', 'M06', 'M062X', 'WB97X', 'WB97X-D3', 'WB97M-V',
-            'CAM-B3LYP', 'B97-3C', 'R2SCAN-3C', 'PBEH-3C',
-            'HF', 'RHF', 'UHF', 'ROHF',
+            'B3LYP', 'B3LYP-D3', 'PBE', 'PBE0', 'BP86', 'BLYP', 'TPSS', 'TPSS0', 'TPSSH',
+            'M06', 'M06L', 'M062X', 'M06-2X', 'WB97', 'WB97X', 'WB97X-D', 'WB97X-D3', 'WB97M-V',
+            'CAM-B3LYP', 'B97', 'B97-D', 'B97D', 'B97-3C', 'R2SCAN', 'R2SCAN0', 'R2SCAN50', 'R2SCAN-3C',
+            'RSCAN', 'SCAN', 'SCANFUNC', 'PBEH-3C', 'HF', 'HFS', 'RHF', 'UHF', 'ROHF', 'VWN5',
             'MP2', 'RI-MP2', 'DLPNO-MP2',
             'CCSD', 'CCSD(T)', 'DLPNO-CCSD', 'DLPNO-CCSD(T)',
             'CASSCF', 'NEVPT2'
@@ -166,12 +167,22 @@ export function parseOrcaOutputEnhanced(content: string): ParsedResults {
             'DEF2-SV(P)', 'MA-DEF2-SVP', 'MA-DEF2-TZVP',
             'CC-PVDZ', 'CC-PVTZ', 'CC-PVQZ', 'CC-PV5Z',
             'AUG-CC-PVDZ', 'AUG-CC-PVTZ', 'AUG-CC-PVQZ',
-            '6-31G', '6-31G*', '6-31G**', '6-311G', '6-311G*', '6-311G**',
-            'STO-3G', '3-21G', '6-311+G*', '6-311+G**',
+            '6-31G', '6-31G*', '6-31G**', '6-31G(D)', '6-311G', '6-311G*', '6-311G**',
+            '6-311+G*', '6-311+G**', '6-311+G(D,P)',
+            'STO-3G', '3-21G', 'LANL2DZ', 'SDD',
             'PC-1', 'PC-2', 'PC-3', 'PCSSEG-1', 'PCSSEG-2'
         ];
         // Calculation types
         const calcTypes = ['OPT', 'FREQ', 'OPTFREQ', 'SP', 'ENGRAD', 'MD', 'NEB', 'TS', 'GRADIENT', 'NUMFREQ'];
+        
+        // Handle multi-token methods (e.g., "B3LYP D3")
+        for (let i = 0; i < keywords.length - 1; i++) {
+            const twoToken = keywords[i] + ' ' + keywords[i + 1];
+            if (twoToken === 'B3LYP D3' && !result.method) {
+                result.method = 'B3LYP-D3';
+                break;
+            }
+        }
         
         for (const kw of keywords) {
             if (methods.includes(kw) && !result.method) {

--- a/src/test/suite/outputParser.test.ts
+++ b/src/test/suite/outputParser.test.ts
@@ -514,4 +514,74 @@ Line 6`;
         assert.ok(Array.isArray(result.tocEntries), 'tocEntries should be an array');
         assert.ok(result.tocEntries.length > 0, 'tocEntries should not be empty for valid content');
     });
+
+    test('should extract method from input line - M06-2X', () => {
+        const content = `
+                         INPUT FILE
+                         ==========
+    ! M06-2X def2-SVP
+
+            FINAL SINGLE POINT ENERGY      -76.123456789
+        `;
+
+        const result = parseOrcaOutputEnhanced(content);
+        assert.strictEqual(result.method, 'M06-2X', 'Should extract M06-2X method');
+        assert.strictEqual(result.basis, 'DEF2-SVP', 'Should extract def2-SVP basis');
+    });
+
+    test('should extract method from input line - B97D', () => {
+        const content = `
+                         INPUT FILE
+                         ==========
+    ! B97D cc-pVTZ
+
+            FINAL SINGLE POINT ENERGY      -76.123456789
+        `;
+
+        const result = parseOrcaOutputEnhanced(content);
+        assert.strictEqual(result.method, 'B97D', 'Should extract B97D method');
+        assert.strictEqual(result.basis, 'CC-PVTZ', 'Should extract cc-pVTZ basis');
+    });
+
+    test('should extract method from input line - SCANfunc', () => {
+        const content = `
+                         INPUT FILE
+                         ==========
+    ! SCANfunc def2-TZVP
+
+            FINAL SINGLE POINT ENERGY      -76.123456789
+        `;
+
+        const result = parseOrcaOutputEnhanced(content);
+        assert.strictEqual(result.method, 'SCANFUNC', 'Should extract SCANfunc method');
+        assert.strictEqual(result.basis, 'DEF2-TZVP', 'Should extract def2-TZVP basis');
+    });
+
+    test('should extract method from input line - B3LYP D3 (multi-token)', () => {
+        const content = `
+                         INPUT FILE
+                         ==========
+    ! B3LYP D3 6-311+G(d,P)
+
+            FINAL SINGLE POINT ENERGY      -76.123456789
+        `;
+
+        const result = parseOrcaOutputEnhanced(content);
+        assert.strictEqual(result.method, 'B3LYP-D3', 'Should extract B3LYP D3 method as B3LYP-D3');
+        assert.strictEqual(result.basis, '6-311+G(D,P)', 'Should extract 6-311+G(d,P) basis');
+    });
+
+    test('should extract basis set with parentheses - 6-311+G(d,P)', () => {
+        const content = `
+                         INPUT FILE
+                         ==========
+    ! PBE0 6-311+G(d,P)
+
+            FINAL SINGLE POINT ENERGY      -76.123456789
+        `;
+
+        const result = parseOrcaOutputEnhanced(content);
+        assert.strictEqual(result.method, 'PBE0', 'Should extract PBE0 method');
+        assert.strictEqual(result.basis, '6-311+G(D,P)', 'Should extract 6-311+G(d,P) basis with parentheses');
+    });
 });


### PR DESCRIPTION
## Summary

This PR expands the Input Creation feature's functional and basis set options as requested in #17.

## Changes

### Snippets Updated (`snippets/orca.json`)
- **8 snippets** updated with expanded options: `sp`, `opt`, `freq`, `optfreq`, `ts`, `cpcm`, `tddft`, `neb`
- **34 functionals** organized by category:
  - Common: B3LYP, B3LYP D3, CAM-B3LYP, wB97X-D, wB97X-D3, wB97M-V, M06, M06-2X, TPSSh
  - Local: HFS, VWN5
  - GGA: PBE, BLYP, BP86, B97D
  - Meta-GGA: M06L, SCANfunc, RSCAN, R2SCAN
  - Hybrid: PBE0, B97, TPSS0, r2SCAN0, r2SCAN50
  - Range-Separated: wB97, wB97X
  - Wavefunction: HF, MP2, RI-MP2, DLPNO-MP2, CCSD, CCSD(T), CASSCF, NEVPT2
- **14 basis sets**: 6-31G(d), 6-31G*, 6-311G, 6-311+G(d,P), def2-SVP, def2-TZVP, def2-QZVP, cc-pVDZ, cc-pVTZ, aug-cc-pVTZ, LANL2DZ, SDD, pc-1, pc-2

### Output Parser Updated (`src/outputParser.ts`)
- Expanded `methods` array with 16 additional functionals
- Expanded `basisSets` array with 4 additional basis sets
- All entries use UPPERCASE for consistent matching

## Testing
- [x] JSON syntax validation passed
- [x] TypeScript compilation passed
- [x] No lint errors

## Closes
Closes #17
