### PR TITLE
feat(completion): add keyword IntelliSense with descriptions for .inp files

### DIFF
--- a/src/data/orcaKeywordDefs.ts
+++ b/src/data/orcaKeywordDefs.ts
@@ -18,6 +18,13 @@ export const simpleKeywords: Record<string, KeywordDefinition> = {
 		example: '! B3LYP def2-TZVP',
 		relatedKeywords: ['PBE0', 'CAM-B3LYP', 'wB97X-D3', 'M06-2X']
 	},
+	'B3LYP D3': {
+		name: 'B3LYP D3',
+		category: 'DFT Functional',
+		description: 'B3LYP hybrid functional with Grimme\'s D3 dispersion correction. Adds empirical atom-pair dispersion terms to B3LYP, improving accuracy for non-covalent interactions, van der Waals complexes, and large organic molecules.',
+		example: '! B3LYP D3 def2-SVP',
+		relatedKeywords: ['B3LYP', 'B3LYP-D3BJ', 'PBE-D3', 'wB97X-D3']
+	},
 	'PBE': {
 		name: 'PBE',
 		category: 'GGA DFT Functional',
@@ -151,6 +158,104 @@ export const simpleKeywords: Record<string, KeywordDefinition> = {
 		example: '! r2SCAN def2-TZVP',
 		relatedKeywords: ['SCAN', 'TPSS', 'M06-L']
 	},
+	'WB97X-D': {
+		name: 'wB97X-D',
+		category: 'Range-Separated Hybrid DFT',
+		description: 'Chai-Head-Gordon range-separated hybrid functional with D2 empirical dispersion. Released 2008; precursor to wB97X-D3. Range separation parameter ω=0.2 bohr⁻¹. Found extensively in older literature.',
+		example: '! wB97X-D def2-TZVP',
+		relatedKeywords: ['wB97X-D3', 'wB97X', 'CAM-B3LYP']
+	},
+	'WB97M-V': {
+		name: 'wB97M-V',
+		category: 'Range-Separated Meta-Hybrid DFT',
+		description: 'Range-separated meta-GGA hybrid functional with VV10 non-local correlation. Head-Gordon group. Excellent broad accuracy for thermochemistry, kinetics, and non-covalent interactions.',
+		example: '! wB97M-V def2-TZVP',
+		relatedKeywords: ['wB97X-D3', 'wB97X-D', 'M06-2X']
+	},
+	'HFS': {
+		name: 'HFS',
+		category: 'LDA Exchange Functional',
+		description: 'Hartree-Fock-Slater (Slater X-alpha) exchange-only functional. Simplest DFT approximation using Slater exchange with α=2/3. Historically significant; purely a local exchange with no correlation.',
+		example: '! HFS def2-SVP',
+		relatedKeywords: ['VWN5', 'SVWN5', 'PBE']
+	},
+	'VWN5': {
+		name: 'VWN5',
+		category: 'LDA DFT Functional',
+		description: 'Vosko-Wilk-Nusair LDA correlation functional (parametrization V). Standard LDA correlation used in most modern DFT implementations. Often combined with Slater exchange (SVWN5 = HFS+VWN5).',
+		example: '! VWN5 def2-SVP',
+		relatedKeywords: ['HFS', 'PBE', 'BLYP']
+	},
+	'B97D': {
+		name: 'B97D',
+		category: 'GGA DFT Functional with Dispersion',
+		description: 'Grimme\'s B97-D GGA functional with D1 empirical dispersion. Optimized for non-covalent interaction energies and geometries. Precursor to later B97-D3 variants; widely used in supramolecular chemistry.',
+		example: '! B97D def2-TZVP',
+		relatedKeywords: ['B3LYP-D3BJ', 'PBE-D3BJ', 'wB97X-D']
+	},
+	'M06L': {
+		name: 'M06L',
+		category: 'Meta-GGA DFT Functional',
+		description: 'Local Minnesota meta-GGA functional (no exact exchange); alias for M06-L. Fast and accurate for transition metal systems, organometallics, and solid-state. Good cost-performance ratio.',
+		example: '! M06L def2-SVP',
+		relatedKeywords: ['M06', 'M06-L', 'TPSS']
+	},
+	'SCANFUNC': {
+		name: 'SCANfunc',
+		category: 'Meta-GGA DFT Functional',
+		description: 'SCAN meta-GGA functional, invoked as SCANfunc to avoid conflict with the SCAN geometry-scan keyword. Strongly Constrained and Appropriately Normed functional satisfying all 17 exact constraints.',
+		example: '! SCANfunc def2-TZVP',
+		relatedKeywords: ['R2SCAN', 'RSCAN', 'TPSS']
+	},
+	'RSCAN': {
+		name: 'rSCAN',
+		category: 'Meta-GGA DFT Functional',
+		description: 'Regularized SCAN (rSCAN) meta-GGA functional. Addresses numerical instabilities in SCAN by regularizing kinetic energy density. Intermediate regularization level between SCAN and r2SCAN.',
+		example: '! rSCAN def2-TZVP',
+		relatedKeywords: ['R2SCAN', 'SCANFUNC', 'TPSS']
+	},
+	'B97': {
+		name: 'B97',
+		category: 'GGA DFT Functional',
+		description: 'Handy\'s B97 GGA functional. Parent of the B97 family with fitted exchange and correlation parameters. Good thermochemistry accuracy for a pure GGA. Often used as starting point for dispersion-corrected variants.',
+		example: '! B97 def2-TZVP',
+		relatedKeywords: ['B97D', 'BLYP', 'BP86']
+	},
+	'TPSS0': {
+		name: 'TPSS0',
+		category: 'Meta-GGA Hybrid DFT',
+		description: 'Hybrid TPSS functional with 25% exact exchange. Improved thermochemical accuracy over pure TPSS. Good for transition metal chemistry where a moderate amount of exact exchange is beneficial.',
+		example: '! TPSS0 def2-TZVP',
+		relatedKeywords: ['TPSSh', 'TPSS', 'PBE0']
+	},
+	'R2SCAN0': {
+		name: 'r2SCAN0',
+		category: 'Meta-GGA Hybrid DFT',
+		description: 'Hybrid r2SCAN functional with 25% exact exchange. Combines the regularized meta-GGA with standard hybrid mixing. Improved accuracy over pure r2SCAN for thermochemistry and reaction energies.',
+		example: '! r2SCAN0 def2-TZVP',
+		relatedKeywords: ['R2SCAN', 'R2SCAN50', 'PBE0']
+	},
+	'R2SCAN50': {
+		name: 'r2SCAN50',
+		category: 'Meta-GGA Hybrid DFT',
+		description: 'r2SCAN functional with 50% exact exchange. High exact-exchange content reduces self-interaction error. Suitable for charge-transfer systems and cases requiring strong exchange delocalization correction.',
+		example: '! r2SCAN50 def2-TZVP',
+		relatedKeywords: ['R2SCAN0', 'R2SCAN', 'M06-2X']
+	},
+	'WB97': {
+		name: 'wB97',
+		category: 'Range-Separated DFT Functional',
+		description: 'Original wB97 range-separated functional (Chai and Head-Gordon, 2008). Long-range-corrected GGA with 100% long-range HF exchange. Foundation of the wB97 functional family.',
+		example: '! wB97 def2-TZVP',
+		relatedKeywords: ['WB97X', 'WB97X-D', 'CAM-B3LYP']
+	},
+	'WB97X': {
+		name: 'wB97X',
+		category: 'Range-Separated Hybrid DFT',
+		description: 'wB97X range-separated hybrid (Chai and Head-Gordon, 2008). Adds a fraction of short-range HF exchange to wB97. Good thermochemistry, kinetics, and non-covalent interaction performance.',
+		example: '! wB97X def2-TZVP',
+		relatedKeywords: ['WB97', 'WB97X-D', 'WB97X-D3']
+	},
 
 	// Wave Function Methods (6 entries)
 	'HF': {
@@ -194,6 +299,27 @@ export const simpleKeywords: Record<string, KeywordDefinition> = {
 		description: 'Domain-based Local Pair Natural Orbital CCSD(T). Linear-scaling coupled-cluster approach enabling CCSD(T) accuracy for large systems (100+ atoms). Major breakthrough in computational chemistry.',
 		example: '! DLPNO-CCSD(T) def2-TZVP',
 		relatedKeywords: ['CCSD(T)', 'DLPNO-MP2', 'LPNO-CEPA']
+	},
+	'DLPNO-MP2': {
+		name: 'DLPNO-MP2',
+		category: 'Local Correlation Method',
+		description: 'Domain-Based Local Pair Natural Orbital MP2. Near-linear-scaling MP2 for large systems with controllable accuracy. Significantly cheaper than canonical MP2 while retaining most correlation energy.',
+		example: '! DLPNO-MP2 def2-TZVP',
+		relatedKeywords: ['RI-MP2', 'MP2', 'DLPNO-CCSD(T)']
+	},
+	'CASSCF': {
+		name: 'CASSCF',
+		category: 'Multi-Reference Method',
+		description: 'Complete Active Space SCF. Variational multi-reference method that optimizes both orbitals and CI coefficients within a user-defined active space. Essential for systems with strong static (multi-reference) correlation. Active space defined in %casscf block.',
+		example: '! CASSCF def2-SVP',
+		relatedKeywords: ['NEVPT2', 'MRCI', 'NEVPT2']
+	},
+	'NEVPT2': {
+		name: 'NEVPT2',
+		category: 'Multi-Reference Perturbation Theory',
+		description: 'N-Electron Valence State Perturbation Theory at second order. Post-CASSCF method that adds dynamic correlation. More robust than CASPT2 against intruder states. Recommended for accurate excitation energies and multi-reference systems.',
+		example: '! NEVPT2 def2-SVP',
+		relatedKeywords: ['CASSCF', 'MRCI', 'DLPNO-NEVPT2']
 	},
 
 	// Basis Sets (16 entries)
@@ -311,6 +437,65 @@ export const simpleKeywords: Record<string, KeywordDefinition> = {
 		example: '! DLPNO-CCSD(T) def2-QZVP/C',
 		relatedKeywords: ['def2-QZVPP', 'def2-TZVP/C']
 	},
+	'6-31G(D)': {
+		name: '6-31G(d)',
+		category: 'Basis Set (Pople)',
+		description: 'Pople double-zeta split-valence basis with d-polarization on heavy atoms. Parenthetical notation equivalent to 6-31G*. Historic basis set encountered throughout the DFT literature; def2-SVP recommended for new work.',
+		example: '! B3LYP 6-31G(d)',
+		relatedKeywords: ['6-31G*', 'def2-SVP'],
+		deprecationNote: 'Consider using def2-SVP instead for better balance and auxiliary basis availability.'
+	},
+	'6-311G': {
+		name: '6-311G',
+		category: 'Basis Set (Pople)',
+		description: 'Pople triple-split valence basis without polarization functions. More flexible valence than 6-31G but lacks polarization. Usually extended with * or ** (d/p polarization) or + (diffuse) for practical use.',
+		example: '! B3LYP 6-311G',
+		relatedKeywords: ['6-311G**', '6-31G*', 'def2-TZVP']
+	},
+	'6-311+G(D,P)': {
+		name: '6-311+G(d,P)',
+		category: 'Basis Set (Pople)',
+		description: 'Triple-split Pople basis with diffuse functions and d(heavy)/p(H) polarization. Popular for anions, hydrogen-bonded systems, and molecules with lone pairs. Modern alternatives like def2-TZVP generally preferred.',
+		example: '! B3LYP 6-311+G(d,P)',
+		relatedKeywords: ['6-311G**', 'def2-TZVP', 'aug-cc-pVTZ'],
+		deprecationNote: 'Consider using def2-TZVP or ma-def2-TZVP for better RI compatibility.'
+	},
+	'DEF2-QZVP': {
+		name: 'def2-QZVP',
+		category: 'Basis Set (Quadruple-Zeta)',
+		description: 'Karlsruhe quadruple-zeta valence with one set of polarization functions. Slightly smaller than def2-QZVPP; used for high-accuracy single-point calculations and approaches the basis set limit for most properties.',
+		example: '! PBE0 def2-QZVP',
+		relatedKeywords: ['def2-QZVPP', 'def2-TZVP', 'cc-pVQZ']
+	},
+	'LANL2DZ': {
+		name: 'LANL2DZ',
+		category: 'Basis Set (ECP)',
+		description: 'Los Alamos National Laboratory effective core potential with double-zeta valence basis. Replaces core electrons with a pseudopotential for transition metals and heavy main-group elements. Widely used but older; def2 bases with ECPs preferred for modern work.',
+		example: '! B3LYP LANL2DZ',
+		relatedKeywords: ['SDD', 'def2-SVP', 'def2-TZVP'],
+		deprecationNote: 'Consider def2-SVP or def2-TZVP with built-in ECPs for better accuracy.'
+	},
+	'SDD': {
+		name: 'SDD',
+		category: 'Basis Set (ECP)',
+		description: 'Stuttgart-Dresden effective core potential with double-zeta valence basis. Alternative to LANL2DZ for heavy elements. More modern ECP parametrization; good for transition metals and lanthanides.',
+		example: '! B3LYP SDD',
+		relatedKeywords: ['LANL2DZ', 'def2-SVP', 'def2-TZVP']
+	},
+	'PC-1': {
+		name: 'pc-1',
+		category: 'Basis Set (Polarization-Consistent)',
+		description: 'Jensen\'s polarization-consistent basis set at double-zeta quality. Designed for systematic convergence of DFT energies. More efficient than Pople bases for DFT due to optimized exponents.',
+		example: '! B3LYP pc-1',
+		relatedKeywords: ['PC-2', 'def2-SVP', 'cc-pVDZ']
+	},
+	'PC-2': {
+		name: 'pc-2',
+		category: 'Basis Set (Polarization-Consistent)',
+		description: 'Jensen\'s polarization-consistent basis set at triple-zeta quality. Higher level in the pc-n series. Systematic convergence of DFT energies; often more efficient than def2-TZVP for pure DFT calculations.',
+		example: '! B3LYP pc-2',
+		relatedKeywords: ['PC-1', 'def2-TZVP', 'cc-pVTZ']
+	},
 
 	// Job Types (8 entries)
 	'OPT': {
@@ -369,6 +554,13 @@ export const simpleKeywords: Record<string, KeywordDefinition> = {
 		example: '! B3LYP def2-TZVP COPT',
 		relatedKeywords: ['Opt', 'Scan', 'Surface']
 	},
+	'NEB-TS': {
+		name: 'NEB-TS',
+		category: 'Job Type',
+		description: 'Nudged Elastic Band with automatic transition state search. Generates a minimum energy path and then refines the transition state from the highest-energy image. More reliable than OptTS when a good TS guess is unavailable.',
+		example: '! B3LYP def2-SVP NEB-TS',
+		relatedKeywords: ['NEB', 'OptTS', 'Freq']
+	},
 
 	// Auxiliary Options (21 entries)
 	'TIGHTSCF': {
@@ -384,6 +576,20 @@ export const simpleKeywords: Record<string, KeywordDefinition> = {
 		description: 'Very tight SCF convergence criteria. Energy convergence to 1e-9 Hartree. Needed for very accurate numerical derivatives and sensitive properties. Increases iteration count.',
 		example: '! PBE0 def2-TZVP VeryTightSCF',
 		relatedKeywords: ['TightSCF', 'ExtremelyTightSCF']
+	},
+	'TIGHTOPT': {
+		name: 'TightOpt',
+		category: 'Geometry Convergence',
+		description: 'Tight geometry optimization convergence thresholds. More stringent than default Opt convergence criteria. Recommended for accurate thermochemistry, reaction energy calculations, and before frequency analyses.',
+		example: '! B3LYP def2-TZVP Opt TightOpt',
+		relatedKeywords: ['VeryTightOpt', 'TightSCF', 'Opt']
+	},
+	'VERYTIGHTOPT': {
+		name: 'VeryTightOpt',
+		category: 'Geometry Convergence',
+		description: 'Very tight geometry optimization convergence thresholds. Maximum practical stringency for geometry optimizations. Use for high-accuracy benchmark reference geometries and numerically sensitive calculations.',
+		example: '! B3LYP def2-TZVP Opt VeryTightOpt',
+		relatedKeywords: ['TightOpt', 'VeryTightSCF', 'Opt']
 	},
 	'SLOWCONV': {
 		name: 'SlowConv',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { OrcaOutputSymbolProvider } from './orcaOutputSymbolProvider';
 import { DashboardPanel } from './dashboard/dashboardPanel';
 import { OrcaCodeLensProvider, OrcaOutputCodeLensProvider } from './orcaCodeLensProvider';
 import { OrcaHoverProvider } from './orcaHoverProvider';
+import { OrcaCompletionProvider } from './orcaCompletionProvider';
 
 let orcaRunner: OrcaRunner;
 let statusBarItem: vscode.StatusBarItem;
@@ -48,6 +49,14 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerHoverProvider(
             { language: 'orca', scheme: 'file' },
             new OrcaHoverProvider()
+        )
+    );
+    
+    // Register completion provider for ORCA input files
+    context.subscriptions.push(
+        vscode.languages.registerCompletionItemProvider(
+            { language: 'orca', scheme: 'file' },
+            new OrcaCompletionProvider()
         )
     );
     

--- a/src/orcaCompletionProvider.ts
+++ b/src/orcaCompletionProvider.ts
@@ -1,0 +1,102 @@
+import * as vscode from 'vscode';
+import { KeywordDefinition } from './orcaHoverProvider';
+import { simpleKeywords } from './data/orcaKeywordDefs';
+
+/**
+ * Completion provider for ORCA input files (.inp)
+ * Provides keyword completions on simple input lines (lines starting with !)
+ */
+export class OrcaCompletionProvider implements vscode.CompletionItemProvider {
+	provideCompletionItems(
+		document: vscode.TextDocument,
+		position: vscode.Position,
+		token: vscode.CancellationToken
+	): vscode.CompletionItem[] {
+		// Task 2.4: Check cancellation first
+		if (token.isCancellationRequested) {
+			return [];
+		}
+
+		const lineText = document.lineAt(position.line).text;
+
+		// Task 2.2: Only operate on simple input lines (starting with !)
+		if (!this.isSimpleInputLine(lineText)) {
+			return [];
+		}
+
+		// Cursor must be strictly after '!' (not at or before it)
+		const trimLen = lineText.length - lineText.trimStart().length;
+		if (position.character <= trimLen) {
+			return [];
+		}
+
+		// Use getWordRangeAtPosition for parity with hover provider (FR-1)
+		const wordRange = document.getWordRangeAtPosition(position, /[\w+*-]+/);
+		const prefix = wordRange ? document.getText(wordRange) : '';
+		const prefixUpper = prefix.toUpperCase();
+
+		// Task 2.3: Build and filter completion items
+		return Object.values(simpleKeywords)
+			.filter(kw => prefixUpper === '' || kw.name.toUpperCase().startsWith(prefixUpper))
+			.map(kw => this.buildCompletionItem(kw, wordRange));
+	}
+
+	/**
+	 * Build a single completion item for a keyword definition.
+	 * The `range` replaces the current word range so VS Code correctly
+	 * substitutes the partial token (AC-US1-5).
+	 * `filterText` is the uppercase key for consistent VS Code filtering (FR-1).
+	 */
+	private buildCompletionItem(
+		kw: KeywordDefinition,
+		wordRange: vscode.Range | undefined
+	): vscode.CompletionItem {
+		const item = new vscode.CompletionItem(kw.name, vscode.CompletionItemKind.Keyword);
+		item.detail = kw.category;
+		item.documentation = this.buildDocumentation(kw);
+		item.insertText = kw.name;
+		item.filterText = kw.name.toUpperCase();
+
+		// Replace the current word range with the full keyword name
+		if (wordRange) {
+			item.range = wordRange;
+		}
+
+		return item;
+	}
+
+	/**
+	 * Build MarkdownString documentation for a keyword.
+	 * Format matches hover provider formatSimpleKeyword for parity (FR-4).
+	 * isTrusted is explicitly set to false (NFR-Security).
+	 */
+	private buildDocumentation(kw: KeywordDefinition): vscode.MarkdownString {
+		const md = new vscode.MarkdownString();
+		md.isTrusted = false; // Security: never trust user-derived content
+
+		// Title: **KEYWORD** — Category
+		md.appendMarkdown(`**${kw.name}** — ${kw.category}\n\n`);
+
+		// Description
+		md.appendMarkdown(`${kw.description}\n\n`);
+
+		if (kw.example) {
+			md.appendMarkdown(`*Example:* \`${kw.example}\`\n\n`);
+		}
+
+		if (kw.deprecationNote) {
+			md.appendMarkdown(`⚠️ **Deprecated:** ${kw.deprecationNote}\n\n`);
+		}
+
+		return md;
+	}
+
+	/**
+	 * Returns true if the line is a simple keyword input line (starts with ! after optional whitespace).
+	 */
+	private isSimpleInputLine(line: string): boolean {
+		return line.trimStart().startsWith('!');
+	}
+
+
+}

--- a/src/test/suite/orcaCompletionProvider.test.ts
+++ b/src/test/suite/orcaCompletionProvider.test.ts
@@ -1,0 +1,442 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { OrcaCompletionProvider } from '../../orcaCompletionProvider';
+import { KeywordDefinition } from '../../orcaHoverProvider';
+
+suite('OrcaCompletionProvider Test Suite', () => {
+	// Helper to create a minimal mock document (same pattern as OrcaHoverProvider tests)
+	function createMockDocument(content: string): vscode.TextDocument {
+		const lines = content.split('\n');
+		return {
+			uri: vscode.Uri.file('/test/file.inp'),
+			fileName: '/test/file.inp',
+			languageId: 'orca',
+			lineCount: lines.length,
+			lineAt: (line: number) => ({
+				text: lines[line] || '',
+				range: new vscode.Range(line, 0, line, lines[line]?.length || 0),
+				lineNumber: line
+			}),
+			getText: (range?: vscode.Range) => {
+				if (!range) { return content; }
+				const line = lines[range.start.line] || '';
+				return line.substring(range.start.character, range.end.character);
+			},
+			getWordRangeAtPosition: (position: vscode.Position, regex?: RegExp) => {
+				const line = lines[position.line] || '';
+				const pattern = regex || /[\w]+/;
+				let start = position.character;
+				let end = position.character;
+				while (start > 0 && pattern.test(line[start - 1])) { start--; }
+				while (end < line.length && pattern.test(line[end])) { end++; }
+				if (start === end) { return undefined; }
+				return new vscode.Range(position.line, start, position.line, end);
+			}
+		} as any;
+	}
+
+	test('Provider class instantiates without errors', () => {
+		assert.doesNotThrow(() => new OrcaCompletionProvider());
+	});
+
+	test('Provider implements provideCompletionItems method', () => {
+		const provider = new OrcaCompletionProvider();
+		assert.strictEqual(typeof provider.provideCompletionItems, 'function');
+	});
+
+	// =========================================================================
+	// Task 2.1 — TDD: Returns completions when cursor is on a ! line
+	// =========================================================================
+
+	suite('Returns completions when cursor is on a ! keyword line', () => {
+		test('Returns non-empty array for "! B3LYP" at end of line', () => {
+			const provider = new OrcaCompletionProvider();
+			const doc = createMockDocument('! B3LYP');
+			const pos = new vscode.Position(0, 7);
+			const token = new vscode.CancellationTokenSource().token;
+
+			const result = provider.provideCompletionItems(doc, pos, token);
+			assert.ok(Array.isArray(result), 'Should return an array');
+			assert.ok(result.length > 0, 'Should return at least one completion item');
+		});
+
+		test('Returns non-empty array for "! " line (cursor after space)', () => {
+			const provider = new OrcaCompletionProvider();
+			const doc = createMockDocument('! ');
+			const pos = new vscode.Position(0, 2);
+			const token = new vscode.CancellationTokenSource().token;
+
+			const result = provider.provideCompletionItems(doc, pos, token);
+			assert.ok(Array.isArray(result));
+			assert.ok(result.length > 0, 'Space-after-! line should return all keywords');
+		});
+	});
+
+	// =========================================================================
+	// Task 2.1 — Returns empty array when cursor is NOT on a ! line
+	// =========================================================================
+
+	suite('Returns empty array for non-! lines', () => {
+		const nonInputLines: Array<{ label: string; text: string }> = [
+			{ label: '* xyz comment',    text: '* xyz' },
+			{ label: '%scf block',       text: '%scf' },
+			{ label: 'blank line',       text: '' },
+			{ label: 'end keyword',      text: 'end' },
+			{ label: 'coordinate line',  text: 'C   0.0 0.0 0.0' },
+			{ label: 'charge/mult line', text: '0 1' },
+		];
+
+		nonInputLines.forEach(({ label, text }) => {
+			test(`Returns [] for "${label}"`, () => {
+				const provider = new OrcaCompletionProvider();
+				const doc = createMockDocument(text);
+				const pos = new vscode.Position(0, Math.min(2, text.length));
+				const token = new vscode.CancellationTokenSource().token;
+
+				const result = provider.provideCompletionItems(doc, pos, token);
+				assert.deepStrictEqual(result, [], `Expected [] for line: "${text}"`);
+			});
+		});
+	});
+
+	// =========================================================================
+	// Task 2.1 — Typing "B3" returns at least B3LYP
+	// =========================================================================
+
+	test('Typing "B3" on a ! line returns at least B3LYP', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('! B3');
+		const pos = new vscode.Position(0, 4); // cursor after '! B3'
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		const labels = result.map(item => item.label as string);
+		assert.ok(labels.includes('B3LYP'),
+			`Expected B3LYP in results. Got: [${labels.join(', ')}]`);
+	});
+
+	// =========================================================================
+	// Task 2.3 — Completion item structure (label, detail, documentation, kind)
+	// =========================================================================
+
+	suite('Completion item has correct structure (label, detail, documentation, kind)', () => {
+		let items: vscode.CompletionItem[];
+
+		setup(() => {
+			const provider = new OrcaCompletionProvider();
+			// Empty prefix — returns all keywords so we test the whole set
+			const doc = createMockDocument('! ');
+			const pos = new vscode.Position(0, 2);
+			const token = new vscode.CancellationTokenSource().token;
+			items = provider.provideCompletionItems(doc, pos, token);
+		});
+
+		test('At least 50 keywords returned for empty prefix', () => {
+			assert.ok(items.length >= 50, `Expected ≥50 items, got ${items.length}`);
+		});
+
+		test('Each item has a non-empty string label (keyword name)', () => {
+			for (const item of items) {
+				assert.strictEqual(typeof item.label, 'string',
+					`Item label should be a string, got ${typeof item.label}`);
+				assert.ok((item.label as string).length > 0, 'Label must not be empty');
+			}
+		});
+
+		test('Each item has a non-empty string detail (category)', () => {
+			for (const item of items) {
+				assert.ok(item.detail,
+					`Item "${item.label}" should have detail (category). Got: ${item.detail}`);
+				assert.strictEqual(typeof item.detail, 'string');
+			}
+		});
+
+		test('Each item has MarkdownString documentation', () => {
+			for (const item of items) {
+				assert.ok(item.documentation,
+					`Item "${item.label}" should have documentation`);
+				assert.ok(item.documentation instanceof vscode.MarkdownString,
+					`Item "${item.label}" documentation should be a MarkdownString`);
+			}
+		});
+
+		test('Each item has kind = CompletionItemKind.Keyword', () => {
+			for (const item of items) {
+				assert.strictEqual(item.kind, vscode.CompletionItemKind.Keyword,
+					`Item "${item.label}" kind should be Keyword (${vscode.CompletionItemKind.Keyword})`);
+			}
+		});
+	});
+
+	// =========================================================================
+	// AC-US1-5 — Selection replaces the typed prefix (range covers prefix)
+	// =========================================================================
+
+	test('AC-US1-5: item.range replaces the typed prefix', () => {
+		const provider = new OrcaCompletionProvider();
+		// Line "! B3": cursor at 4, prefix "B3" starts at character 2
+		const doc = createMockDocument('! B3');
+		const pos = new vscode.Position(0, 4);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.ok(result.length > 0, 'Need at least one item to test range');
+
+		for (const item of result) {
+			assert.ok(item.range,
+				`Item "${item.label}" should have range set for prefix replacement`);
+			const range = item.range as vscode.Range;
+			// Prefix "B3" starts at character index 2, cursor at 4
+			assert.strictEqual(range.start.character, 2,
+				`Range start should be at prefix start (char 2), got ${range.start.character}`);
+			assert.strictEqual(range.end.character, 4,
+				`Range end should be at cursor position (char 4), got ${range.end.character}`);
+		}
+	});
+
+	test('AC-US1-5: no range set when prefix is empty (cursor on empty ! line)', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('! ');
+		const pos = new vscode.Position(0, 2);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.ok(result.length > 0, 'Need items');
+		// No range needed when prefix is empty — VS Code default insertion applies
+		for (const item of result) {
+			assert.strictEqual(item.range, undefined,
+				`Item "${item.label}" should not have an explicit range when prefix is empty`);
+		}
+	});
+
+	// =========================================================================
+	// AC-US2-4 — deprecationNote included in documentation MarkdownString
+	// =========================================================================
+
+	test('AC-US2-4: deprecationNote is included in documentation markdown', () => {
+		const provider = new OrcaCompletionProvider() as any; // access private method
+		const deprecatedKw: KeywordDefinition = {
+			name: '6-31G*',
+			category: 'Basis Set (Pople)',
+			description: 'Legacy Pople split-valence basis.',
+			deprecationNote: 'Consider using def2-SVP instead.'
+		};
+
+		const md = provider.buildDocumentation(deprecatedKw) as vscode.MarkdownString;
+		assert.ok(md.value.includes('⚠️'), 'Documentation should include warning emoji');
+		assert.ok(md.value.includes('Deprecated'), 'Documentation should include "Deprecated"');
+		assert.ok(md.value.includes('def2-SVP'), 'Documentation should include the deprecation note text');
+	});
+
+	test('AC-US2-4: no deprecation section when deprecationNote is absent', () => {
+		const provider = new OrcaCompletionProvider() as any;
+		const normalKw: KeywordDefinition = {
+			name: 'B3LYP',
+			category: 'Hybrid DFT Functional',
+			description: 'Becke 3-parameter Lee-Yang-Parr hybrid functional.'
+		};
+
+		const md = provider.buildDocumentation(normalKw) as vscode.MarkdownString;
+		assert.ok(!md.value.includes('⚠️'), 'Non-deprecated keyword should not have warning emoji');
+		assert.ok(!md.value.includes('Deprecated'), 'Non-deprecated keyword should not mention Deprecated');
+	});
+
+	// =========================================================================
+	// NFR-Security — All MarkdownString instances must have isTrusted = false
+	// =========================================================================
+
+	test('NFR-Security: all MarkdownString instances have isTrusted = false', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('! ');
+		const pos = new vscode.Position(0, 2);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.ok(result.length > 0, 'Need items to validate security property');
+
+		for (const item of result) {
+			const md = item.documentation as vscode.MarkdownString;
+			assert.strictEqual(md.isTrusted, false,
+				`Item "${item.label}": MarkdownString.isTrusted must be false (security requirement)`);
+		}
+	});
+
+	// =========================================================================
+	// Edge cases (Task 2.4)
+	// =========================================================================
+
+	test('Edge: empty ! line (just "!") returns all keywords', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('!');
+		const pos = new vscode.Position(0, 1); // cursor right after '!'
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.ok(result.length >= 50,
+			`Expected ≥50 keywords for empty ! line, got ${result.length}`);
+	});
+
+	test('Edge: line without ! returns []', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('B3LYP def2-TZVP');
+		const pos = new vscode.Position(0, 5);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.deepStrictEqual(result, []);
+	});
+
+	test('Edge: cursor before ! in leading whitespace returns []', () => {
+		const provider = new OrcaCompletionProvider();
+		// Line "   ! B3LYP": '!' is at index 3, cursor at index 1 (before '!')
+		const doc = createMockDocument('   ! B3LYP');
+		const pos = new vscode.Position(0, 1);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.deepStrictEqual(result, [],
+			'Cursor before ! (in leading whitespace) should return []');
+	});
+
+	// =========================================================================
+	// Task 2.4 — Cancellation token check
+	// =========================================================================
+
+	test('2.4: Returns [] immediately when cancellation token is already cancelled', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('! B3LYP');
+		const pos = new vscode.Position(0, 7);
+		const source = new vscode.CancellationTokenSource();
+		source.cancel(); // cancel before calling provider
+
+		const result = provider.provideCompletionItems(doc, pos, source.token);
+		assert.deepStrictEqual(result, [],
+			'Cancelled token must cause provider to return empty array immediately');
+	});
+
+	// =========================================================================
+	// Task 2.5 — Snippet placeholder non-interference
+	// =========================================================================
+
+	test('2.5: Cursor inside snippet ${} placeholder returns no completions', () => {
+		// Snippet placeholder text like ${1|B3LYP,PBE|} does not start with '!'
+		// so the provider naturally returns [] — no special handling needed
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('${1|B3LYP,PBE|}');
+		const pos = new vscode.Position(0, 5);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		assert.deepStrictEqual(result, [],
+			'Snippet placeholder lines (no !) should return no completions');
+	});
+
+	// =========================================================================
+	// Task 2.6 — isIncomplete return contract: plain array, not CompletionList
+	// =========================================================================
+
+	test('2.6: Returns plain CompletionItem[] not vscode.CompletionList', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('! ');
+		const pos = new vscode.Position(0, 2);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+
+		// Must be a plain JavaScript array
+		assert.ok(Array.isArray(result), 'Result must be a plain array, not a CompletionList');
+		// vscode.CompletionList has an isIncomplete property; plain arrays do not
+		assert.strictEqual((result as any).isIncomplete, undefined,
+			'Result must not have isIncomplete property (that would indicate a CompletionList)');
+	});
+
+	// =========================================================================
+	// Task 2.3 — Documentation builder edge cases
+	// =========================================================================
+
+	test('2.3: Example block included in documentation when keyword has example', () => {
+		const provider = new OrcaCompletionProvider() as any;
+		const kw: KeywordDefinition = {
+			name: 'B3LYP',
+			category: 'Hybrid DFT Functional',
+			description: 'Test description.',
+			example: '! B3LYP def2-TZVP'
+		};
+
+		const md = provider.buildDocumentation(kw) as vscode.MarkdownString;
+		assert.ok(md.value.includes('*Example:*'), 'Should include Example header');
+		assert.ok(md.value.includes('! B3LYP def2-TZVP'), 'Should include example code');
+	});
+
+	test('2.3: No example block when keyword has no example', () => {
+		const provider = new OrcaCompletionProvider() as any;
+		const kw: KeywordDefinition = {
+			name: 'TESTFUNC',
+			category: 'Test',
+			description: 'Test description without example.'
+		};
+
+		const md = provider.buildDocumentation(kw) as vscode.MarkdownString;
+		assert.ok(!md.value.includes('*Example:*'), 'Should not include Example section');
+	});
+
+	test('2.3: Case-insensitive prefix matching — "b3" matches B3LYP', () => {
+		const provider = new OrcaCompletionProvider();
+		const doc = createMockDocument('! b3');
+		const pos = new vscode.Position(0, 4);
+		const token = new vscode.CancellationTokenSource().token;
+
+		const result = provider.provideCompletionItems(doc, pos, token);
+		const labels = result.map(item => item.label as string);
+		assert.ok(labels.includes('B3LYP'),
+			'Lowercase prefix "b3" should match keyword "B3LYP" (case-insensitive)');
+	});
+
+	// =========================================================================
+	// Integration: real catalog keywords
+	// =========================================================================
+
+	suite('Integration with real keyword catalog', () => {
+		test('B3LYP completion has correct category "Hybrid DFT Functional"', () => {
+			const provider = new OrcaCompletionProvider();
+			const doc = createMockDocument('! B3LYP');
+			const pos = new vscode.Position(0, 7);
+			const token = new vscode.CancellationTokenSource().token;
+
+			const result = provider.provideCompletionItems(doc, pos, token);
+			const b3lyp = result.find(item => item.label === 'B3LYP');
+			assert.ok(b3lyp, 'B3LYP completion must exist in catalog');
+			assert.strictEqual(b3lyp.detail, 'Hybrid DFT Functional');
+		});
+
+		test('6-31G* completion includes deprecation note from real catalog', () => {
+			const provider = new OrcaCompletionProvider();
+			// Use prefix "6-31" to get the deprecated Pople basis sets
+			const doc = createMockDocument('! 6-31');
+			const pos = new vscode.Position(0, 6);
+			const token = new vscode.CancellationTokenSource().token;
+
+			const result = provider.provideCompletionItems(doc, pos, token);
+			const deprecated = result.find(item => item.label === '6-31G*');
+			assert.ok(deprecated, '6-31G* completion must exist in catalog');
+
+			const md = deprecated.documentation as vscode.MarkdownString;
+			assert.ok(md.value.includes('⚠️'),
+				'6-31G* documentation should include deprecation warning');
+			assert.ok(md.value.includes('Deprecated'),
+				'6-31G* documentation should include "Deprecated"');
+		});
+
+		test('PBE completion has correct category "GGA DFT Functional"', () => {
+			const provider = new OrcaCompletionProvider();
+			const doc = createMockDocument('! PBE');
+			const pos = new vscode.Position(0, 5);
+			const token = new vscode.CancellationTokenSource().token;
+
+			const result = provider.provideCompletionItems(doc, pos, token);
+			const pbe = result.find(item => item.label === 'PBE');
+			assert.ok(pbe, 'PBE completion must exist in catalog');
+			assert.strictEqual(pbe.detail, 'GGA DFT Functional');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add keyword IntelliSense completions with descriptions for ORCA `.inp` files. When typing on a `!` keyword line, users now see documented completions showing what each method, basis set, or keyword does.

## Changes

### New: `src/orcaCompletionProvider.ts`
- `OrcaCompletionProvider` class implementing `vscode.CompletionItemProvider`
- Activates only on `!` keyword lines (no interference with other line types)
- Each completion shows: keyword name, category (detail), description + example (documentation)
- All `MarkdownString` instances have `isTrusted = false` (security)
- Returns `CompletionItem[]` (not `CompletionList`) to preserve snippet dropdown coexistence

### Modified: `src/extension.ts`
- Registered `OrcaCompletionProvider` for `orca` language, immediately after the hover provider

### Modified: `src/data/orcaKeywordDefs.ts`
- Added 29 missing keyword entries covering all snippet choice values:
  - DFT functionals: `wB97X-D`, `wB97M-V`, `HFS`, `VWN5`, `B97D`, `M06L`, `SCANfunc`, `RSCAN`, `B97`, `TPSS0`, `r2SCAN0`, `r2SCAN50`, `wB97`, `wB97X`, `B3LYP D3`
  - Wave function: `DLPNO-MP2`, `CASSCF`, `NEVPT2`
  - Basis sets: `6-31G(d)`, `6-31G*`, `6-311G`, `6-311+G(d,P)`, `def2-QZVP`, `LANL2DZ`, `SDD`, `pc-1`, `pc-2`
  - Job types: `NEB-TS`
  - Convergence: `TightOpt`, `VeryTightOpt`

### New: `src/test/suite/orcaCompletionProvider.test.ts`
- Full TDD test suite (added to the 203-test suite)
- Covers: line context detection, prefix matching, item structure, security, edge cases, snippet non-interference, isIncomplete contract

## Testing

- [x] `npm run compile` — passes, no errors
- [x] `npm run lint` — 0 errors (warnings are pre-existing patterns)
- [x] `npm test` — 203 passing, 0 failures
- [x] Snippet choice dropdowns (`opt`, `sp`, `freq`, etc.) — unchanged, `snippets/orca.json` not modified

## Non-breaking

Snippet dropdowns continue to work as before. The new completion provider is additive — it activates on word-based triggers and Ctrl+Space when on a `!` line.
